### PR TITLE
FIXED: Issue #46: AutoGrid Utility class '.col-5' works same as '.col-4'

### DIFF
--- a/src/css/utilities/autogrid.css
+++ b/src/css/utilities/autogrid.css
@@ -6,9 +6,15 @@
  */
 
 .auto-grid {
+	align-items: flex-start;
 	display: flex;
-	justify-content: space-between;
+	flex-direction: row !important;
 	flex-wrap: wrap;
+	justify-content: space-between;
+}
+
+.auto-grid.deck {
+	align-items: normal;
 }
 
 .auto-grid > * {
@@ -16,7 +22,7 @@
 }
 
 .auto-grid.col-5 > * {
-	flex: 1 0 20%;
+	flex: 1 0 15%;
 }
 
 .auto-grid.col-4 > * {


### PR DESCRIPTION
FIXED: Issue #46: AutoGrid Utility class '.col-5' works same as '.col-4'